### PR TITLE
Improve battle feel: equipment stats, item drops, CSS animations

### DIFF
--- a/apps/web/app/(game)/battle/page.tsx
+++ b/apps/web/app/(game)/battle/page.tsx
@@ -1,26 +1,127 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { trpc } from "@/lib/trpc";
 import { StatusPanel } from "@/components/game/status-panel";
 import { BattleLog } from "@/components/game/battle-log";
 import { HpGauge } from "@/components/game/hp-gauge";
 import Link from "next/link";
 
+interface EnemyState {
+  id: number;
+  enemy: { name: string; level: number; hp: number };
+  currentHp: number;
+  shaking: boolean;
+  defeated: boolean;
+  damagePopup: { value: number; key: number } | null;
+}
+
+interface BattleRewards {
+  exp: number;
+  rails: number;
+  levelUp: number | null;
+  drops?: { itemName: string; count: number }[];
+}
+
 export default function BattlePage() {
   const { data: player, refetch: refetchPlayer } = trpc.player.me.useQuery();
-  const { data: battleStatus, refetch: refetchBattle } = trpc.battle.status.useQuery();
+  const { data: battleStatus, refetch: refetchBattle } =
+    trpc.battle.status.useQuery();
   const [log, setLog] = useState<string[]>([]);
   const [battleResult, setBattleResult] = useState<{
     victory: boolean;
-    rewards: { exp: number; rails: number; levelUp: number | null } | null;
+    rewards: BattleRewards | null;
   } | null>(null);
+  const [enemyStates, setEnemyStates] = useState<EnemyState[]>([]);
+  const [showScreenFlash, setShowScreenFlash] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [showVictory, setShowVictory] = useState(false);
+  const popupKeyRef = useRef(0);
+
+  useEffect(() => {
+    if (battleStatus?.enemies) {
+      setEnemyStates((prev) => {
+        if (prev.length > 0) return prev;
+        return battleStatus.enemies.map((e) => ({
+          id: e.id,
+          enemy: e.enemy,
+          currentHp: e.currentHp,
+          shaking: false,
+          defeated: false,
+          damagePopup: null,
+        }));
+      });
+    }
+  }, [battleStatus]);
+
+  const animateEvents = useCallback(
+    async (events: any[], newLog: string[]) => {
+      setIsAnimating(true);
+
+      for (const event of events) {
+        if (event.type === "playerAttack") {
+          popupKeyRef.current++;
+          const pKey = popupKeyRef.current;
+
+          setEnemyStates((prev) =>
+            prev.map((es) =>
+              es.id === event.targetId
+                ? {
+                    ...es,
+                    shaking: true,
+                    currentHp: event.enemyHp,
+                    damagePopup: { value: event.damage, key: pKey },
+                  }
+                : es
+            )
+          );
+
+          await sleep(400);
+
+          setEnemyStates((prev) =>
+            prev.map((es) =>
+              es.id === event.targetId
+                ? {
+                    ...es,
+                    shaking: false,
+                    damagePopup: null,
+                    defeated: event.killed ? true : es.defeated,
+                  }
+                : es
+            )
+          );
+
+          if (event.killed) {
+            await sleep(600);
+          } else {
+            await sleep(150);
+          }
+        } else if (event.type === "enemyAttack") {
+          setShowScreenFlash(true);
+          await sleep(300);
+          setShowScreenFlash(false);
+          await sleep(150);
+        } else if (event.type === "playerDefeated") {
+          await sleep(400);
+        } else if (event.type === "victory") {
+          await sleep(300);
+          setShowVictory(true);
+        }
+      }
+
+      setLog((prev) => [...prev, ...newLog]);
+      setIsAnimating(false);
+    },
+    []
+  );
 
   const encounterMutation = trpc.battle.encounter.useMutation({
     onSuccess: (data) => {
       if (data.encountered) {
         setLog(["敵が現れた！"]);
         setBattleResult(null);
+        setShowVictory(false);
+        setEnemyStates([]);
         refetchBattle();
       } else {
         setLog(["敵は現れなかった..."]);
@@ -30,12 +131,17 @@ export default function BattlePage() {
 
   const attackMutation = trpc.battle.attack.useMutation({
     onSuccess: (data) => {
-      setLog((prev) => [...prev, ...data.log]);
       if (data.battleEnd) {
         setBattleResult({ victory: data.victory, rewards: data.rewards });
         refetchBattle();
       }
       refetchPlayer();
+
+      if (data.events && data.events.length > 0) {
+        animateEvents(data.events, data.log);
+      } else {
+        setLog((prev) => [...prev, ...data.log]);
+      }
     },
   });
 
@@ -53,38 +159,62 @@ export default function BattlePage() {
   const inBattle = !!battleStatus;
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 relative">
+      {showScreenFlash && (
+        <div className="fixed inset-0 bg-destructive z-50 pointer-events-none animate-screen-flash" />
+      )}
+
       <div className="lg:col-span-2 space-y-6">
         <h1 className="font-heading text-3xl text-primary">バトル</h1>
 
         {!inBattle && !battleResult && (
           <div className="rpg-frame p-6 space-y-4">
-            <p className="text-muted-foreground">
-              探索して敵を見つけましょう
-            </p>
+            <p className="text-muted-foreground">探索して敵を見つけましょう</p>
             <button
               onClick={() => encounterMutation.mutate()}
               disabled={encounterMutation.isPending}
-              className="w-full py-3 rounded bg-destructive text-destructive-foreground font-bold hover:bg-destructive/90 disabled:opacity-50"
+              className="w-full py-3 rounded bg-destructive text-destructive-foreground font-bold hover:bg-destructive/90 disabled:opacity-50 transition-colors"
             >
               {encounterMutation.isPending ? "探索中..." : "探索する"}
             </button>
           </div>
         )}
 
-        {inBattle && battleStatus && (
+        {inBattle && battleStatus && !battleResult && (
           <div className="rpg-frame p-6 space-y-4">
-            <h2 className="font-heading text-lg text-destructive">⚔️ 戦闘中</h2>
+            <h2 className="font-heading text-lg text-destructive">
+              戦闘中
+            </h2>
+
             <div className="space-y-3">
-              {battleStatus.enemies.map((e) => (
-                <div key={e.id} className="rpg-frame p-3 space-y-2">
-                  <div className="flex justify-between items-center">
-                    <span className="font-bold">{e.enemy.name}</span>
+              {enemyStates.map((es) => (
+                <div
+                  key={es.id}
+                  className={`rpg-frame p-4 relative overflow-hidden transition-all ${
+                    es.shaking ? "animate-battle-shake" : ""
+                  } ${es.defeated ? "animate-enemy-defeat" : ""}`}
+                >
+                  <div className="flex justify-between items-center mb-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-lg">
+                        {getEnemyEmoji(es.enemy.name)}
+                      </span>
+                      <span className="font-bold">{es.enemy.name}</span>
+                    </div>
                     <span className="text-xs text-muted-foreground">
-                      Lv.{e.enemy.level}
+                      Lv.{es.enemy.level}
                     </span>
                   </div>
-                  <HpGauge current={e.currentHp} max={e.enemy.hp} />
+                  <HpGauge current={es.currentHp} max={es.enemy.hp} />
+
+                  {es.damagePopup && (
+                    <div
+                      key={es.damagePopup.key}
+                      className="absolute top-2 right-4 text-2xl font-bold text-destructive animate-damage-pop pointer-events-none"
+                    >
+                      -{es.damagePopup.value}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
@@ -92,15 +222,19 @@ export default function BattlePage() {
             <div className="flex gap-3">
               <button
                 onClick={() => attackMutation.mutate()}
-                disabled={attackMutation.isPending}
-                className="flex-1 py-3 rounded bg-destructive text-destructive-foreground font-bold hover:bg-destructive/90 disabled:opacity-50"
+                disabled={attackMutation.isPending || isAnimating}
+                className="flex-1 py-3 rounded bg-destructive text-destructive-foreground font-bold hover:bg-destructive/90 disabled:opacity-50 transition-colors"
               >
-                攻撃
+                {isAnimating ? "攻撃中..." : "攻撃"}
               </button>
               <button
                 onClick={() => escapeMutation.mutate()}
-                disabled={escapeMutation.isPending}
-                className="flex-1 py-3 rounded bg-secondary text-foreground font-bold hover:bg-secondary/80 disabled:opacity-50"
+                disabled={
+                  escapeMutation.isPending ||
+                  isAnimating ||
+                  attackMutation.isPending
+                }
+                className="flex-1 py-3 rounded bg-secondary text-foreground font-bold hover:bg-secondary/80 disabled:opacity-50 transition-colors"
               >
                 逃走
               </button>
@@ -109,33 +243,87 @@ export default function BattlePage() {
         )}
 
         {battleResult && (
-          <div className="rpg-frame-gold p-6 space-y-4">
+          <div
+            className={`rpg-frame-gold p-6 space-y-4 ${showVictory ? "animate-victory-glow" : ""}`}
+          >
             <h2 className="font-heading text-lg text-primary">
-              {battleResult.victory ? "🎉 勝利！" : "💀 敗北..."}
+              {battleResult.victory ? "勝利！" : "敗北..."}
             </h2>
+
             {battleResult.rewards && (
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span>獲得EXP</span>
-                  <span className="text-exp font-bold">+{battleResult.rewards.exp}</span>
+              <div className="space-y-3">
+                <div className="flex justify-between items-center animate-slide-up">
+                  <span className="text-sm">獲得EXP</span>
+                  <span className="text-exp font-bold text-lg">
+                    +{battleResult.rewards.exp}
+                  </span>
                 </div>
-                <div className="flex justify-between">
-                  <span>獲得Rails</span>
-                  <span className="text-gold font-bold">+{battleResult.rewards.rails}</span>
+                <div
+                  className="flex justify-between items-center animate-slide-up"
+                  style={{ animationDelay: "0.1s" }}
+                >
+                  <span className="text-sm">獲得Rails</span>
+                  <span className="text-gold font-bold text-lg">
+                    +{battleResult.rewards.rails}
+                  </span>
                 </div>
+
                 {battleResult.rewards.levelUp && (
-                  <div className="text-primary font-bold text-center text-lg mt-2">
-                    🎊 レベルアップ！ → Lv.{battleResult.rewards.levelUp}
+                  <div
+                    className="text-primary font-bold text-center text-xl mt-2 animate-slide-up"
+                    style={{ animationDelay: "0.2s" }}
+                  >
+                    レベルアップ！ Lv.{battleResult.rewards.levelUp}
                   </div>
                 )}
+
+                {battleResult.rewards.drops &&
+                  battleResult.rewards.drops.length > 0 && (
+                    <div
+                      className="mt-4 pt-3 border-t border-border animate-slide-up"
+                      style={{ animationDelay: "0.3s" }}
+                    >
+                      <h3 className="text-sm font-bold text-primary mb-2">
+                        ドロップアイテム
+                      </h3>
+                      <div className="space-y-1">
+                        {battleResult.rewards.drops.map((drop, i) => (
+                          <div
+                            key={i}
+                            className="flex justify-between items-center text-sm"
+                          >
+                            <span>{drop.itemName}</span>
+                            <span className="text-primary font-bold">
+                              x{drop.count}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
               </div>
             )}
-            <Link
-              href="/area"
-              className="block w-full py-3 rounded bg-primary text-primary-foreground font-bold text-center hover:bg-primary/90"
-            >
-              エリアに戻る
-            </Link>
+
+            <div className="flex gap-3 mt-4">
+              <Link
+                href="/area"
+                className="flex-1 py-3 rounded bg-primary text-primary-foreground font-bold text-center hover:bg-primary/90 transition-colors"
+              >
+                エリアに戻る
+              </Link>
+              <button
+                onClick={() => {
+                  setBattleResult(null);
+                  setShowVictory(false);
+                  setEnemyStates([]);
+                  encounterMutation.mutate();
+                }}
+                disabled={encounterMutation.isPending}
+                className="flex-1 py-3 rounded bg-destructive text-destructive-foreground font-bold hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+              >
+                続けて探索
+              </button>
+            </div>
           </div>
         )}
 
@@ -145,4 +333,19 @@ export default function BattlePage() {
       <div>{player && <StatusPanel player={player} />}</div>
     </div>
   );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getEnemyEmoji(name: string): string {
+  const map: Record<string, string> = {
+    スライム: "🟢",
+    ゴブリン: "👺",
+    オオカミ: "🐺",
+    オーク: "👹",
+    トロール: "🧌",
+  };
+  return map[name] ?? "👾";
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -76,3 +76,65 @@ body {
 .hp-critical {
   animation: hp-pulse 1s ease-in-out infinite;
 }
+
+/* Battle animations */
+@keyframes battle-shake {
+  0%, 100% { transform: translateX(0); }
+  10% { transform: translateX(-6px) rotate(-1deg); }
+  30% { transform: translateX(6px) rotate(1deg); }
+  50% { transform: translateX(-4px); }
+  70% { transform: translateX(4px); }
+  90% { transform: translateX(-2px); }
+}
+
+@keyframes damage-pop {
+  0% { opacity: 0; transform: translateY(0) scale(0.5); }
+  20% { opacity: 1; transform: translateY(-10px) scale(1.2); }
+  50% { opacity: 1; transform: translateY(-24px) scale(1); }
+  100% { opacity: 0; transform: translateY(-40px) scale(0.8); }
+}
+
+@keyframes enemy-defeat {
+  0% { opacity: 1; transform: scale(1); filter: brightness(1); }
+  30% { opacity: 1; transform: scale(1.05); filter: brightness(2); }
+  100% { opacity: 0; transform: scale(0.6); filter: brightness(0.5); }
+}
+
+@keyframes screen-flash {
+  0% { opacity: 0.35; }
+  100% { opacity: 0; }
+}
+
+@keyframes victory-glow {
+  0%, 100% { box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.3), 0 0 8px rgba(212, 168, 67, 0.15); }
+  50% { box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.3), 0 0 20px rgba(212, 168, 67, 0.4), 0 0 40px rgba(212, 168, 67, 0.15); }
+}
+
+@keyframes slide-up-fade {
+  0% { opacity: 0; transform: translateY(12px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.animate-battle-shake {
+  animation: battle-shake 0.4s ease-out;
+}
+
+.animate-damage-pop {
+  animation: damage-pop 0.8s ease-out forwards;
+}
+
+.animate-enemy-defeat {
+  animation: enemy-defeat 0.6s ease-out forwards;
+}
+
+.animate-screen-flash {
+  animation: screen-flash 0.3s ease-out forwards;
+}
+
+.animate-victory-glow {
+  animation: victory-glow 2s ease-in-out infinite;
+}
+
+.animate-slide-up {
+  animation: slide-up-fade 0.4s ease-out forwards;
+}

--- a/apps/web/components/game/battle-log.tsx
+++ b/apps/web/components/game/battle-log.tsx
@@ -33,7 +33,8 @@ export function BattleLog({ messages, className }: BattleLogProps) {
             msg.includes("倒した") && "text-primary font-bold",
             msg.includes("力尽きた") && "text-destructive font-bold",
             msg.includes("レベルアップ") && "text-exp font-bold",
-            msg.includes("回復") && "text-hp"
+            msg.includes("回復") && "text-hp",
+            msg.includes("ドロップ") && "text-gold font-bold"
           )}
         >
           {`> ${msg}`}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -4,7 +4,7 @@ import { levels } from "./schema/levels";
 import { towns, establishments } from "./schema/towns";
 import { roads } from "./schema/roads";
 import { areas, areaNodes, routes } from "./schema/areas";
-import { items } from "./schema/items";
+import { items, itemLotteries } from "./schema/items";
 import { equipment } from "./schema/equipment";
 import { enemies, enemyMaps } from "./schema/enemies";
 import { shops, shopProducts, showcases } from "./schema/shops";
@@ -153,15 +153,15 @@ async function seed() {
     .onConflictDoNothing();
   console.log("  Inserted equipment");
 
-  // --- Enemies ---
+  // --- Enemies (itemLotteryGroupId links to itemLotteries.groupId) ---
   const insertedEnemies = await db
     .insert(enemies)
     .values([
-      { name: "スライム", description: "弱い魔物", str: 3, defense: 1, hp: 15, rails: 5, exp: 5, level: 1, dex: 1, damageMin: 1, damageMax: 4 },
-      { name: "ゴブリン", description: "小さな緑の魔物", str: 6, defense: 2, hp: 25, rails: 10, exp: 10, level: 2, dex: 3, damageMin: 3, damageMax: 7 },
-      { name: "オオカミ", description: "素早い獣", str: 8, defense: 3, hp: 30, rails: 15, exp: 15, level: 3, dex: 6, damageMin: 5, damageMax: 10, criticalHitChance: 10, criticalHitDamage: 150 },
-      { name: "オーク", description: "力の強い大型の魔物", str: 15, defense: 8, hp: 60, rails: 30, exp: 30, level: 5, dex: 3, damageMin: 10, damageMax: 20 },
-      { name: "トロール", description: "巨大な魔物", str: 20, defense: 12, hp: 100, rails: 50, exp: 50, level: 8, dex: 2, damageMin: 15, damageMax: 30, damageReduction: 5 },
+      { name: "スライム", description: "弱い魔物", str: 3, defense: 1, hp: 15, rails: 5, exp: 5, level: 1, dex: 1, damageMin: 1, damageMax: 4, dropItemRate: 50, itemLotteryGroupId: 1 },
+      { name: "ゴブリン", description: "小さな緑の魔物", str: 6, defense: 2, hp: 25, rails: 10, exp: 10, level: 2, dex: 3, damageMin: 3, damageMax: 7, dropItemRate: 45, itemLotteryGroupId: 2 },
+      { name: "オオカミ", description: "素早い獣", str: 8, defense: 3, hp: 30, rails: 15, exp: 15, level: 3, dex: 6, damageMin: 5, damageMax: 10, criticalHitChance: 10, criticalHitDamage: 150, dropItemRate: 40, itemLotteryGroupId: 3 },
+      { name: "オーク", description: "力の強い大型の魔物", str: 15, defense: 8, hp: 60, rails: 30, exp: 30, level: 5, dex: 3, damageMin: 10, damageMax: 20, dropItemRate: 35, itemLotteryGroupId: 4 },
+      { name: "トロール", description: "巨大な魔物", str: 20, defense: 12, hp: 100, rails: 50, exp: 50, level: 8, dex: 2, damageMin: 15, damageMax: 30, damageReduction: 5, dropItemRate: 30, itemLotteryGroupId: 5 },
     ])
     .onConflictDoNothing()
     .returning();
@@ -180,6 +180,31 @@ async function seed() {
     ])
     .onConflictDoNothing();
   console.log("  Inserted enemy maps");
+
+  // --- Item Lotteries (drop tables: groupId matches enemy.itemLotteryGroupId) ---
+  await db
+    .insert(itemLotteries)
+    .values([
+      // Group 1: スライム drops
+      { groupId: 1, itemId: insertedItems[7].id, count: 1, weight: 80, compositeGroupId: 1 },  // スライムゼリー
+      { groupId: 1, itemId: insertedItems[0].id, count: 1, weight: 20, compositeGroupId: 1 },  // 薬草
+      // Group 2: ゴブリン drops
+      { groupId: 2, itemId: insertedItems[8].id, count: 1, weight: 70, compositeGroupId: 2 },  // ゴブリンの牙
+      { groupId: 2, itemId: insertedItems[0].id, count: 1, weight: 30, compositeGroupId: 2 },  // 薬草
+      // Group 3: オオカミ drops
+      { groupId: 3, itemId: insertedItems[9].id, count: 1, weight: 70, compositeGroupId: 3 },  // 狼の毛皮
+      { groupId: 3, itemId: insertedItems[0].id, count: 2, weight: 30, compositeGroupId: 3 },  // 薬草 x2
+      // Group 4: オーク drops
+      { groupId: 4, itemId: insertedItems[10].id, count: 1, weight: 60, compositeGroupId: 4 }, // 鉄鉱石
+      { groupId: 4, itemId: insertedItems[8].id, count: 2, weight: 25, compositeGroupId: 4 },  // ゴブリンの牙 x2
+      { groupId: 4, itemId: insertedItems[1].id, count: 1, weight: 15, compositeGroupId: 4 },  // 回復薬
+      // Group 5: トロール drops
+      { groupId: 5, itemId: insertedItems[10].id, count: 2, weight: 50, compositeGroupId: 5 }, // 鉄鉱石 x2
+      { groupId: 5, itemId: insertedItems[9].id, count: 2, weight: 30, compositeGroupId: 5 },  // 狼の毛皮 x2
+      { groupId: 5, itemId: insertedItems[1].id, count: 2, weight: 20, compositeGroupId: 5 },  // 回復薬 x2
+    ])
+    .onConflictDoNothing();
+  console.log("  Inserted item lotteries (drop tables)");
 
   // --- Shops ---
   const insertedShops = await db


### PR DESCRIPTION
## Summary

- バトルのダメージ計算に装備ステータス（武器の攻撃力/ダメージ、防具の防御力）を反映
- 攻撃ボタン1回で1ターン完結するようリファクタ（全敵に攻撃 → 生存敵が反撃）
- 敵撃破時のアイテムドロップシステムを実装（既存の `itemLotteries` スキーマを活用）
- 全5種の敵にドロップ率とドロップテーブルのシードデータを追加
- バトルUIにCSSアニメーション追加（攻撃シェイク、ダメージ数字ポップアップ、撃破フェードアウト、被ダメ画面フラッシュ、勝利時フレーム輝き）
- 勝利画面にドロップアイテム一覧表示と「続けて探索」ボタンを追加

## Changed files

- `apps/server/src/trpc/routers/battle.ts` - 装備参照、1ターン完結化、ドロップロジック
- `apps/web/app/(game)/battle/page.tsx` - バトルUI全面刷新 + アニメーション
- `apps/web/app/globals.css` - バトル用CSSアニメーション定義
- `apps/web/components/game/battle-log.tsx` - ドロップメッセージのハイライト
- `packages/db/src/seed.ts` - ドロップテーブルシードデータ追加

## Test plan

- [ ] 装備なしで戦闘し、素手ダメージ（STR基準）が正しく計算されることを確認
- [ ] 武器・防具を装備して戦闘し、ダメージ増加/被ダメ減少を確認
- [ ] 攻撃ボタン1回で全敵への攻撃 + 敵の反撃が1ターンで完了することを確認
- [ ] 敵撃破後にアイテムがドロップし、インベントリに追加されることを確認
- [ ] 勝利画面にドロップアイテムが表示されることを確認
- [ ] 各CSSアニメーション（シェイク、ダメージポップアップ、撃破フェード、画面フラッシュ、勝利グロー）が動作することを確認
- [ ] 「続けて探索」ボタンで連続バトルが可能なことを確認
- [ ] seed再投入後、itemLotteriesデータが正しく入ることを確認


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Equipment now impacts damage calculations during combat encounters.
  * Enemies may drop items upon defeat, which are added to your inventory.
  * Added dynamic battle animations including damage indicators, character shake effects, and victory celebrations.
  * Screen flash effects now appear during enemy attacks for enhanced feedback.

* **Style**
  * Implemented new CSS animations for improved visual battle experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->